### PR TITLE
Fix Fetch Depth PR

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
         with:
-          fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}
+          fetch-depth: 0
       - name: Generate Matrix Action
         id: set-matrix
         uses: submitty/action-docker-matrix@v24.06.00


### PR DESCRIPTION
On some PRs, the fetch depth will be 2 which will not clone the whole history of the repository. Due to how https://github.com/Submitty/action-docker-matrix knows which Dockerfiles to build, a long history is required.